### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,5 @@
     "@unocss/nuxt": "^66.0.0",
     "nuxt": "^4.0.0"
   },
-  "packageManager": "pnpm@10.33.4"
+  "packageManager": "pnpm@11.1.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  '@parcel/watcher': false
+  esbuild: false
+  unrs-resolver: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`